### PR TITLE
feat: Adds example for listing USB Bluetooth devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Your Linux user must have permissions to access USB hardware. Here are several o
   ```
   Replace `your_vendor_id` and `your_product_id` with the actual vendor and product IDs of your device (you can find these using `lsusb`). Then reload udev rules with `sudo udevadm control --reload-rules && sudo udevadm trigger`.
 
+### MacOs
+In MacOs you may have to install `fmt` and `libusb`. For more information about troubleshooting read the [usage document](Usage.md) for more information.
+
 ## Contributors
 
 Special thanks to [Tarlogic Security](https://github.com/TarlogicSecurity/) for sponsoring part of the development of this project via paid work hours.

--- a/Usage.md
+++ b/Usage.md
@@ -11,12 +11,38 @@ You must also link against the library or use a shared library version. For this
 The library is distributed y binary format available in https://github.com/antoniovazquezblanco/usbbluetooth/releases.
 The library may also be available for installation via your favourite package manager.
 
+### Macos
+If you will use `brew` as your package manager you need to install first `fmt` and `libusb`.
+
+```bash
+brew install fmt libusb
+meson setup build --wipe --wrap-mode=forcefallback
+cd build
+sudo meson install
+```
+
+The command `meson setup build --wipe --wrap-mode=forcefallback` is to ensure non-cached packages.
+
+In case an error with the `ccache` and versions, run the `brew reinstall ccache`.
+```bash
+# Example error
+[1/5] Compiling C object src/usbbt/usbbt.p/main.c.o
+FAILED: [code=134] src/usbbt/usbbt.p/main.c.o 
+ccache cc -Isrc/usbbt/usbbt.p -Isrc/usbbt -I../src/usbbt -Isrc/libusbbluetooth -I../src/libusbbluetooth -I../subprojects/cwalk-1.2.9/include -I/opt/homebrew/Cellar/libusb/1.0.29/include/libusb-1.0 -fdiagnostics-color=always -Wall -Winvalid-pch -O0 -g -MD -MQ src/usbbt/usbbt.p/main.c.o -MF src/usbbt/usbbt.p/main.c.o.d -o src/usbbt/usbbt.p/main.c.o -c ../src/usbbt/main.c
+dyld[32146]: Library not loaded: /opt/homebrew/opt/fmt/lib/libfmt.11.dylib
+  Referenced from: <3FE95377-F54E-353D-9397-74E23EA42650> /opt/homebrew/Cellar/ccache/4.11.3_1/bin/ccache
+  Reason: tried: '/opt/homebrew/opt/fmt/lib/libfmt.11.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/fmt/lib/libfmt.11.dylib' (no such file), '/opt/homebrew/opt/fmt/lib/libfmt.11.dylib' (no such file), '/opt/homebrew/Cellar/fmt/12.1.0/lib/libfmt.11.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/fmt/12.1.0/lib/libfmt.11.dylib' (no such file), '/opt/homebrew/Cellar/fmt/12.1.0/lib/libfmt.11.dylib' (no such file)
+[3/5] Linking target src/libusbbluetooth/libusbbluetooth.dylib
+ninja: build stopped: subcommand failed.  
+```
+
 You can also choose to compile it for you platform.
 To compile the project just follow the common steps to compile using meson.
 
 ```bash
 meson setup build
 meson compile -C build
+cd build
 sudo meson install
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,42 @@
+# Examples
+## devices.c
+
+This example shows how to list all available USB Bluetooth devices detected by the usbbluetooth library.
+
+### Build
+```bash
+# macOS and Linux
+gcc devices.c -o devices $(pkg-config --cflags --libs usbbluetooth)
+```
+
+### Common build error
+
+On some systems (especially when installing via Homebrew on macOS), you may encounter an error similar to the following:
+```bash
+/usr/local/include/usbbluetooth/usbbluetooth.h:4:10: error: 'usbbluetooth_err.h' file not found with <angled> include; use "quotes" instead
+    4 | #include <usbbluetooth_err.h>
+      |          ^~~~~~~~~~~~~~~~~~~~
+      |          "usbbluetooth_err.h"
+In file included from devices.c:5:
+In file included from /usr/local/include/usbbluetooth/usbbluetooth.h:4:
+/usr/local/include/usbbluetooth/usbbluetooth_err.h:4:10: error: 'usbbluetooth_api.h' file not found with <angled> include; use "quotes" instead
+    4 | #include <usbbluetooth_api.h>
+      |          ^~~~~~~~~~~~~~~~~~~~
+      |          "usbbluetooth_api.h"
+
+```
+This happens because the usbbluetooth headers are located in a subdirectory that is not automatically added to the compiler include paths.
+
+### Fix
+
+Explicitly add the usbbluetooth include directory using -I:
+```bash
+gcc devices.c -o devices \
+    $(pkg-config --cflags --libs usbbluetooth) \
+    -I/opt/homebrew/include/usbbluetooth
+```
+## Notes
+
+The include path may vary depending on your operating system and installation method.
+
+Before compiling, verify the actual installation path of the headers (for example, using `pkg-config --cflags usbbluetooth` or `brew info usbbluetooth` on macOS).

--- a/examples/devices.c
+++ b/examples/devices.c
@@ -1,0 +1,48 @@
+/*
+Author: Kevin Leon
+Date: 24/12/2025
+*/
+#include <usbbluetooth/usbbluetooth.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+  int ret = 0;
+
+  // Initialize the library...
+  usbbluetooth_status_t r = usbbluetooth_init();
+  if (r < 0)
+  {
+      fprintf(stderr, "Could not initialize usbbluetooth (r=%d, s=%s)\n", (int)r, usbbluetooth_status_name(r));
+      ret = -1;
+      return ret;
+  }
+
+  // List all available devices...
+  usbbluetooth_device_t **devs = NULL;
+  r = usbbluetooth_get_device_list(&devs);
+  if (r < 0)
+  {
+      fprintf(stderr, "Could get a device list (r=%d, s=%s)\n", (int)r, usbbluetooth_status_name(r));
+      ret = -1;
+      return ret;
+  }
+
+  // Show device list
+  printf("[*] Bluetooth USB devices:\n");
+
+  for (int i = 0; devs[i] != NULL; i++){
+    char *desc = usbbluetooth_device_description(devs[i]);
+    
+    if (desc){
+      printf("[%d] %s\n", i, desc);
+      free(desc);
+    }
+  }
+
+  // Free and liberate
+  usbbluetooth_free_device_list(&devs);
+  usbbluetooth_exit();
+  return ret;
+}


### PR DESCRIPTION
Introduces a new example that demonstrates how to list available USB Bluetooth devices using the library.

Also includes a README file with instructions on how to build and fix common build errors, specifically for macOS users.

Updates the main README and Usage documentation with troubleshooting information.
